### PR TITLE
Add new template for reminder pick up emails

### DIFF
--- a/emails/class-finishing-email.php
+++ b/emails/class-finishing-email.php
@@ -176,18 +176,20 @@ class Finishing_Email extends WC_Email {
 
     // return the subject
     function get_subject() {
-
-        $order = new WC_order( $this->object->order_id );
-        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $this->subject ), $this->object );
-
+        // check if user defined subject exists, else use default subject
+        $subject = ! empty( $this->settings['subject'] )
+            ? $this->settings['subject']
+            : $this->subject;
+        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $subject ), $this->object );
     }
 
     // return the email heading
     public function get_heading() {
-
-        $order = new WC_order( $this->object->order_id );
-        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $this->heading ), $this->object );
-
+        // check if user defined heading exists, else use default heading
+        $heading = ! empty( $this->settings['heading'] )
+            ? $this->settings['heading']
+            : $this->heading;
+        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $heading ), $this->object );
     }
 
     // form fields that are displayed in WooCommerce->Settings->Emails

--- a/emails/class-pony-email.php
+++ b/emails/class-pony-email.php
@@ -176,18 +176,20 @@ class Pony_Email extends WC_Email {
 
     // return the subject
     function get_subject() {
-
-        $order = new WC_order( $this->object->order_id );
-        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $this->subject ), $this->object );
-
+        // check if user defined subject exists, else use default subject
+        $subject = ! empty( $this->settings['subject'] )
+            ? $this->settings['subject']
+            : $this->subject;
+        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $subject ), $this->object );
     }
 
     // return the email heading
     public function get_heading() {
-
-        $order = new WC_order( $this->object->order_id );
-        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $this->heading ), $this->object );
-
+        // check if user defined heading exists, else use default heading
+        $heading = ! empty( $this->settings['heading'] )
+            ? $this->settings['heading']
+            : $this->heading;
+        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $heading ), $this->object );
     }
 
     // form fields that are displayed in WooCommerce->Settings->Emails

--- a/emails/class-proof-ready-email.php
+++ b/emails/class-proof-ready-email.php
@@ -176,18 +176,20 @@ class Proof_Ready_Email extends WC_Email {
 
     // return the subject
     function get_subject() {
-
-        $order = new WC_order( $this->object->order_id );
-        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $this->subject ), $this->object );
-
+        // check if user defined subject exists, else use default subject
+        $subject = ! empty( $this->settings['subject'] )
+            ? $this->settings['subject']
+            : $this->heading;
+        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $subject ), $this->object );
     }
 
     // return the email heading
     public function get_heading() {
-
-        $order = new WC_order( $this->object->order_id );
-        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $this->heading ), $this->object );
-
+        // check if user defined heading exists, else use default heading
+        $heading = ! empty( $this->settings['heading'] )
+            ? $this->settings['heading']
+            : $this->subject;
+        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $heading ), $this->object );
     }
 
     // form fields that are displayed in WooCommerce->Settings->Emails

--- a/emails/class-ready-for-pickup-email.php
+++ b/emails/class-ready-for-pickup-email.php
@@ -176,18 +176,20 @@ class Ready_For_Pickup_Email extends WC_Email {
 
     // return the subject
     function get_subject() {
-
-        $order = new WC_order( $this->object->order_id );
-        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $this->subject ), $this->object );
-
+        // check if user defined subject exists, else use default subject
+        $subject = ! empty( $this->settings['subject'] )
+            ? $this->settings['subject']
+            : $this->subject;
+        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $subject ), $this->object );
     }
 
     // return the email heading
     public function get_heading() {
-
-        $order = new WC_order( $this->object->order_id );
-        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $this->heading ), $this->object );
-
+        // check if user defined subject exists, else use default subject
+        $subject = ! empty( $this->settings['subject'] )
+            ? $this->settings['subject']
+            : $this->heading;
+        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $subject ), $this->object );
     }
 
     // form fields that are displayed in WooCommerce->Settings->Emails

--- a/emails/class-ready-reminder-email.php
+++ b/emails/class-ready-reminder-email.php
@@ -186,19 +186,21 @@ class Ready_Reminder_Email extends WC_Email
     // return the subject
     function get_subject()
     {
-
-        $order = new WC_order( $this->object->order_id );
-        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $this->subject ), $this->object );
-
+        // check if user defined subject exists, else use default subject
+        $subject = ! empty( $this->settings['subject'] )
+            ? $this->settings['subject']
+            : $this->heading;
+        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $subject ), $this->object );
     }
 
     // return the email heading
     public function get_heading()
     {
-
-        $order = new WC_order( $this->object->order_id );
-        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $this->heading ), $this->object );
-
+        // check if user defined heading exists, else use default heading
+        $heading = ! empty( $this->settings['heading'] )
+            ? $this->settings['heading']
+            : $this->heading;
+        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $heading ), $this->object );
     }
 
     // form fields that are displayed in WooCommerce->Settings->Emails

--- a/emails/class-ready-reminder-email.php
+++ b/emails/class-ready-reminder-email.php
@@ -1,0 +1,257 @@
+<?php
+
+/**
+ * Ready For Pick Up Email
+ *
+ * An email class that handles "Ready For Pick Up" order status reminders
+ * @NOTE - This class is not used for status changes. It is only created for reminders by using hooks for its call.
+ *
+ * @class       Ready_Reminder_Email
+ * @extends     WC_Email
+ *
+ */
+class Ready_Reminder_Email extends WC_Email
+{
+
+    function __construct()
+    {
+
+        // Add email ID, title, description, heading, subject
+        $this->id = 'ready_reminder_email';
+        $this->customer_email = true;
+        $this->title = __( 'Ready For Pick Up Reminder Email', 'ready-reminder-email' );
+        $this->description = __( 'This email is received as a reminder for orders that are "Ready for Pick Up".', 'ready-reminder-email' );
+
+        $this->heading = __( 'Ready For Pick Up Reminder', 'ready-reminder-email' );
+        $this->subject = __( '[{blogname}] Order for {product_title} (Order {order_number}) - {order_date}', 'ready-reminder-email' );
+
+        // email template path
+        $this->template_html = 'emails/ready-reminder-email-html.php';
+        $this->template_plain = 'emails/plain/ready-reminder-email-plain.php';
+
+        // Triggers for this email
+        add_action( 'custom_ready_reminder_email_notification', array( $this, 'queue_notification' ) );
+        add_action( 'custom_ready_reminder_email_trigger_notification', array( $this, 'trigger' ) );
+
+        // Call parent constructor
+        parent::__construct();
+
+        // Other settings
+        $this->template_base = CUSTOM_TEMPLATE_PATH;
+        // default recipient to null. This field will be set when trigger pulls order information
+        // and sets it to customer email
+        $this->recipient = null;
+        // placeholders for form fields
+        $this->placeholders = array(
+            '{order_date}' => '',
+            '{order_number}' => '',
+            '{order_billing_full_name}' => '',
+        );
+
+    }
+
+    public function queue_notification( $order_id )
+    {
+
+        $order = new WC_order( $order_id );
+        $items = $order->get_items();
+        // foreach item in the order
+        foreach ( $items as $item_key => $item_value ) {
+            // add an event for the item email, pass the item ID so other details can be collected as needed
+            wp_schedule_single_event( time(), 'custom_ready_reminder_email_trigger', array( 'item_id' => $item_key ) );
+            break;
+        }
+    }
+
+    // This function collects the data and sends the email
+    function trigger( $item_id )
+    {
+
+        $send_email = true;
+        // validations
+        if ( $item_id && $send_email ) {
+            // create an object with item details like name, quantity etc.
+            $this->object = $this->create_object( $item_id );
+
+            // replace the merge tags with valid data
+            $key = array_search( '{product_title}', $this->find );
+            if ( false !== $key ) {
+                unset( $this->find[$key] );
+                unset( $this->replace[$key] );
+            }
+
+            $this->find[] = '{product_title}';
+            $this->replace[] = $this->object->product_title;
+
+            if ( $this->object->order_id ) {
+
+                $this->find[] = '{order_date}';
+                $this->replace[] = date_i18n( wc_date_format(), strtotime( $this->object->order_date ) );
+
+                $this->find[] = '{order_number}';
+                $this->replace[] = $this->object->order_id;
+            } else {
+
+                $this->find[] = '{order_date}';
+                $this->replace[] = __( 'N/A', 'ready-reminder-email' );
+
+                $this->find[] = '{order_number}';
+                $this->replace[] = __( 'N/A', 'ready-reminder-email' );
+            }
+
+            // if no recipient is set, do not send the email
+            if ( !$this->get_recipient() ) {
+                return;
+            }
+            // send the email
+            $this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(),
+                array() );
+
+        }
+    }
+
+    // Create an object with the data to be passed to the templates
+    public function create_object( $item_id )
+    {
+
+        global $wpdb;
+
+        $item_object = new stdClass();
+
+        // order ID
+        $query_order_id = "SELECT order_id FROM `" . $wpdb->prefix . "woocommerce_order_items`
+                            WHERE order_item_id = %d";
+        $get_order_id = $wpdb->get_results( $wpdb->prepare( $query_order_id, $item_id ) );
+
+        $order_id = 0;
+        if ( isset( $get_order_id ) && is_array( $get_order_id ) && count( $get_order_id ) > 0 ) {
+            $order_id = $get_order_id[0]->order_id;
+        }
+        $item_object->order_id = $order_id;
+
+        $order = new WC_order( $order_id );
+        $this->recipient = $order->get_billing_email();
+
+        // order date
+        $post_data = get_post( $order_id );
+        $item_object->order_date = $post_data->post_date;
+
+        // product ID
+        $item_object->product_id = wc_get_order_item_meta( $item_id, '_product_id' );
+
+        // product name
+        $_product = wc_get_product( $item_object->product_id );
+        $item_object->product_title = $_product->get_title();
+
+        // qty
+        $item_object->qty = wc_get_order_item_meta( $item_id, '_qty' );
+
+        // total
+        $item_object->total = wc_price( wc_get_order_item_meta( $item_id, '_line_total' ) );
+
+        // email adress
+        $item_object->billing_email = (version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0) ? $order->billing_email : $order->get_billing_email();
+
+        // customer ID
+        $item_object->customer_id = (version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0) ? $order->user_id : $order->get_user_id();
+
+        return $item_object;
+
+    }
+
+    // return the html content
+    function get_content_html()
+    {
+        ob_start();
+        wc_get_template( $this->template_html, array(
+            'item_data' => $this->object,
+            'email_heading' => $this->get_heading(),
+            'additional_content' => $this->get_additional_content()
+        ), 'custom-templates', $this->template_base );
+        return ob_get_clean();
+    }
+
+    // return the plain content
+    function get_content_plain()
+    {
+        ob_start();
+        wc_get_template( $this->template_plain, array(
+            'item_data' => $this->object,
+            'email_heading' => $this->get_heading(),
+            'additional_content' => $this->get_additional_content()
+        ), 'custom-templates', $this->template_base );
+        return ob_get_clean();
+    }
+
+    // return the subject
+    function get_subject()
+    {
+
+        $order = new WC_order( $this->object->order_id );
+        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $this->subject ), $this->object );
+
+    }
+
+    // return the email heading
+    public function get_heading()
+    {
+
+        $order = new WC_order( $this->object->order_id );
+        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $this->heading ), $this->object );
+
+    }
+
+    // form fields that are displayed in WooCommerce->Settings->Emails
+    function init_form_fields()
+    {
+        $placeholder_text = sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>' . esc_html( implode( '</code>, <code>', array_keys( $this->placeholders ) ) ) . '</code>' );
+        $this->form_fields = array(
+            'enabled' => array(
+                'title' => __( 'Enable/Disable', 'ready-reminder-email' ),
+                'type' => 'checkbox',
+                'label' => __( 'Enable this email notification', 'ready-reminder-email' ),
+                'default' => 'yes'
+            ),
+            'subject' => array(
+                'title' => __( 'Subject', 'ready-reminder-email' ),
+                'type' => 'text',
+                'description' => sprintf( __( 'This controls the email subject line. Leave blank to use the default subject: <code>%s</code>.', 'ready-reminder-email' ), $this->subject ),
+                'placeholder' => '',
+                'default' => ''
+            ),
+            'heading' => array(
+                'title' => __( 'Email Heading', 'ready-reminder-email' ),
+                'type' => 'text',
+                'description' => sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>.', 'ready-reminder-email' ), $this->heading ),
+                'placeholder' => '',
+                'default' => ''
+            ),
+            'additional_content' => array(
+                'title' => __( 'Additional content', 'ready-reminder-email' ),
+                'description' => __( 'Text to appear below the main email content.', 'ready-reminder-email' ) . ' ' .
+                    $placeholder_text,
+                'css' => 'width:400px; height: 75px;',
+                'placeholder' => __( 'N/A', 'ready-reminder-email' ),
+                'type' => 'textarea',
+                'default' => $this->get_default_additional_content(),
+                'desc_tip' => true,
+            ),
+            'email_type' => array(
+                'title' => __( 'Email type', 'ready-reminder-email' ),
+                'type' => 'select',
+                'description' => __( 'Choose which format of email to send.', 'ready-reminder-email' ),
+                'default' => 'html',
+                'class' => 'email_type',
+                'options' => array(
+                    'plain' => __( 'Plain text', 'ready-reminder-email' ),
+                    'html' => __( 'HTML', 'ready-reminder-email' ),
+                    'multipart' => __( 'Multipart', 'ready-reminder-email' ),
+                )
+            )
+        );
+    }
+
+}
+
+return new Ready_Reminder_Email();
+

--- a/emails/class-special-email.php
+++ b/emails/class-special-email.php
@@ -178,18 +178,20 @@ class Special_Email extends WC_Email {
 
     // return the subject
     function get_subject() {
-
-        $order = new WC_order( $this->object->order_id );
-        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $this->subject ), $this->object );
-
+        // check if user defined subject exists, else use default subject
+        $subject = ! empty( $this->settings['subject'] )
+            ? $this->settings['subject']
+            : $this->heading;
+        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $subject ), $this->object );
     }
 
     // return the email heading
     public function get_heading() {
-
-        $order = new WC_order( $this->object->order_id );
-        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $this->heading ), $this->object );
-
+        // check if user defined heading exists, else use default heading
+        $heading = ! empty( $this->settings['heading'] )
+            ? $this->settings['heading']
+            : $this->heading;
+        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $heading ), $this->object );
     }
 
     // form fields that are displayed in WooCommerce->Settings->Emails

--- a/includes/class-woocommerce-custom-emails-manager.php
+++ b/includes/class-woocommerce-custom-emails-manager.php
@@ -18,6 +18,8 @@ class Custom_Email_Manager {
         add_action( 'woocommerce_order_status_finishing', array( &$this, 'custom_trigger_finishing_action' ), 10, 2 );
         add_action( 'woocommerce_order_status_special', array( &$this, 'custom_trigger_special_action' ), 10, 2 );
         add_action( 'woocommerce_order_status_ready', array( &$this, 'custom_trigger_ready_action' ), 10, 2 );
+        add_action( 'woocommerce_order_status_ready_reminder', array( &$this, 'custom_trigger_ready_reminder_action' ),
+            10, 2 );
         add_action( 'woocommerce_order_status_proof', array( &$this, 'custom_trigger_proof_action' ), 10, 2 );
         add_action( 'woocommerce_order_status_pony', array( &$this, 'custom_trigger_pony_action' ), 10, 2 );
         // include the email class files
@@ -33,6 +35,7 @@ class Custom_Email_Manager {
             'custom_special_email_trigger',
             'custom_ready_email',
             'custom_ready_email_trigger',
+            'custom_ready_reminder_email_trigger',
             'custom_proof_email',
             'custom_proof_email_trigger',
             'custom_pony_email',
@@ -63,6 +66,10 @@ class Custom_Email_Manager {
 
         if ( ! isset( $emails['Ready_Email']) ) {
             $emails[ 'Ready_Email' ] = include_once( plugin_dir_path(__DIR__) . 'emails/class-ready-for-pickup-email.php' );
+        }
+
+        if ( ! isset( $emais['Ready_Reminder_Email'] ) ) {
+            $emails[ 'Ready_Reminder_Email' ] = include_once( plugin_dir_path(__DIR__) . 'emails/class-ready-reminder-email.php' );
         }
 
         if ( ! isset( $emails['Proof_Email']) ) {
@@ -112,6 +119,16 @@ class Custom_Email_Manager {
 
             WC_Emails::instance();
             do_action( 'custom_ready_email_notification', $order_id );
+
+        }
+    }
+
+    public function custom_trigger_ready_reminder_action( $order_id, $posted ) {
+        // add an action for our email trigger if the order id is valid
+        if ( isset( $order_id ) && 0 != $order_id ) {
+
+            WC_Emails::instance();
+            do_action( 'custom_ready_reminder_email_notification', $order_id );
 
         }
     }

--- a/templates/emails/plain/ready-reminder-email-plain.php
+++ b/templates/emails/plain/ready-reminder-email-plain.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Customer email to notify "Ready For Pick Up"
+ */
+$order = new WC_order( $item_data->order_id );
+
+echo "= " . $email_heading . " =\n\n";
+
+$opening_paragraph = __( '%s, This is a reminder email that your order is ready for pick up. Please come get your order 
+as soon as possible. If this was a mistake, click <a>here</a> to notify the team that your order has been picked up.',
+    'ready-reminder-email' );
+
+$billing_first_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_first_name : $order->get_billing_first_name();
+$billing_last_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_last_name : $order->get_billing_last_name();
+if ( $order && $billing_first_name && $billing_last_name ) {
+    echo sprintf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ) . "\n\n";
+}
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+echo sprintf( __( 'Ordered Product: %s', 'ready-reminder-email' ), $item_data->product_title ) . "\n";
+
+echo sprintf( __( 'Quantity: %s', 'ready-reminder-email' ), $item_data->qty ) . "\n";
+
+echo sprintf( __( 'Total: %s', 'ready-reminder-email' ), $item_data->total ) . "\n";
+
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+echo __( 'This is a custom email sent as the order status has been changed to "Ready for Pick Up".', 'ready-reminder-email'
+    ) .
+    "\n\n";
+
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );

--- a/templates/emails/ready-for-pickup-email-html.php
+++ b/templates/emails/ready-for-pickup-email-html.php
@@ -16,14 +16,6 @@ $billing_last_name = $customer->get_last_name();
 
 if ( $order && $billing_first_name && $billing_last_name ) : ?>
     <p><?php printf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ); ?></p>
-  <p>
-    If you already picked up your order, click on the link below to complete your order. You may need to log in to do
-    the following aciton
-  <form action="<?php echo site_url() . '/my-account/view-order/' . $order->get_id() ?>" method="get">
-    <input id="completed" type="hidden" name="completed" value="1">
-    <button type="submit">I already picked up my order</button>
-  </form>
-  </p>
 <?php endif; ?>
 
 <?php

--- a/templates/emails/ready-for-pickup-email-html.php
+++ b/templates/emails/ready-for-pickup-email-html.php
@@ -16,6 +16,14 @@ $billing_last_name = $customer->get_last_name();
 
 if ( $order && $billing_first_name && $billing_last_name ) : ?>
     <p><?php printf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ); ?></p>
+  <p>
+    If you already picked up your order, click on the link below to complete your order. You may need to log in to do
+    the following aciton
+  <form action="<?php echo site_url() . '/my-account/view-order/' . $order->get_id() ?>" method="get">
+    <input id="completed" type="hidden" name="completed" value="1">
+    <button type="submit">I already picked up my order</button>
+  </form>
+  </p>
 <?php endif; ?>
 
 <?php

--- a/templates/emails/ready-reminder-email-html.php
+++ b/templates/emails/ready-reminder-email-html.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Customer email to reminder custom that order is Ready for Pick Up
+ */
+$order = new WC_order( $item_data->order_id );
+$opening_paragraph = __( '%s, this is a reminder email that your order is ready for pick up. Please come get your order 
+as soon as possible. If this was a mistake, click <a href="<?php site_url() ?>"><b>here</b></a> to notify the team that 
+you have already picked up your order.', 'ready-for-pickup-email' );
+?>
+
+<?php do_action( 'woocommerce_email_header', $email_heading ); ?>
+
+<?php
+$customer = new WC_Customer( $order->get_customer_id() );
+$billing_first_name = $customer->get_first_name();
+$billing_last_name = $customer->get_last_name();
+
+if ( $order && $billing_first_name && $billing_last_name ) : ?>
+    <p><?php printf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ); ?></p>
+<?php endif; ?>
+
+<?php
+/*
+* @hooked WC_Emails::order_details() Shows the order details table.
+* @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+* @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+* @since 2.5.0
+*/
+do_action( 'woocommerce_email_order_details', $order );
+
+/*
+* @hooked WC_Emails::order_meta() Shows order meta data.
+*/
+do_action( 'woocommerce_email_order_meta', $order );
+
+/*
+* @hooked WC_Emails::customer_details() Shows customer details
+* @hooked WC_Emails::email_address() Shows email address
+*/
+do_action( 'woocommerce_email_customer_details', $order );
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+    echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+}
+?>
+
+<?php do_action( 'woocommerce_email_footer' ); ?>

--- a/templates/emails/ready-reminder-email-html.php
+++ b/templates/emails/ready-reminder-email-html.php
@@ -17,6 +17,13 @@ $billing_last_name = $customer->get_last_name();
 
 if ( $order && $billing_first_name && $billing_last_name ) : ?>
     <p><?php printf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ); ?></p>
+    <p>
+      If you already picked up your order, please login to your VTA Document Services Account and follow this link
+      <form action="<?php echo wc_get_page_permalink('/my-account/view-order/' . $order->get_id()) ?>" method="get">
+        <button type="submit"><?php echo wc_get_page_permalink('/my-account/view-order/' . $order->get_id()) ?></button>
+      </form>
+      to mark your order as complete
+    </p>
 <?php endif; ?>
 
 <?php

--- a/templates/emails/ready-reminder-email-html.php
+++ b/templates/emails/ready-reminder-email-html.php
@@ -4,8 +4,7 @@
  */
 $order = new WC_order( $item_data->order_id );
 $opening_paragraph = __( '%s, this is a reminder email that your order is ready for pick up. Please come get your order 
-as soon as possible. If this was a mistake, click <a href="<?php site_url() ?>"><b>here</b></a> to notify the team that 
-you have already picked up your order.', 'ready-for-pickup-email' );
+as soon as possible.', 'ready-for-pickup-email' );
 ?>
 
 <?php do_action( 'woocommerce_email_header', $email_heading ); ?>

--- a/templates/emails/ready-reminder-email-html.php
+++ b/templates/emails/ready-reminder-email-html.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Customer email to reminder custom that order is Ready for Pick Up
+ * Customer email reminder that order is Ready for Pick Up
  */
 $order = new WC_order( $item_data->order_id );
 $opening_paragraph = __( '%s, this is a reminder email that your order is ready for pick up. Please come get your order 
@@ -17,12 +17,26 @@ $billing_last_name = $customer->get_last_name();
 if ( $order && $billing_first_name && $billing_last_name ) : ?>
     <p><?php printf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ); ?></p>
     <p>
-        If you already picked up your order, click on the link below to complete your order. You may need to log in to do
-        the following action
-        <form action="<?php echo site_url() . '/my-account/view-order/' . $order->get_id() ?>" method="get">
-            <input id="completed" type="hidden" name="completed" value="1">
-            <button type="submit">I already picked up my order</button>
-        </form>
+        If you already picked up your order, click on the link below to complete your order. You may need to log in to complete
+        the following action.
+        <a href="<?php echo site_url() . '/my-account/view-order/' . $order->get_id() . '?completed=1' ?>"
+                style="background: #017aca;
+                        color: #fff;
+                        border: none;
+                        cursor: pointer;
+                        display: inline-block;
+                        font-weight: 600;
+                        letter-spacing: 0.0333em;
+                        line-height: 1.25;
+                        margin: 1rem 0;
+                        opacity: 1;
+                        padding: 1.1em 1.44em;
+                        text-align: center;
+                        text-decoration: none;
+                        text-transform: uppercase;
+                        transition: opacity 0.15s linear;">
+            I already picked up my order
+        </a>
     </p>
 <?php endif; ?>
 

--- a/templates/emails/ready-reminder-email-html.php
+++ b/templates/emails/ready-reminder-email-html.php
@@ -18,11 +18,12 @@ $billing_last_name = $customer->get_last_name();
 if ( $order && $billing_first_name && $billing_last_name ) : ?>
     <p><?php printf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ); ?></p>
     <p>
-      If you already picked up your order, please login to your VTA Document Services Account and follow this link
-      <form action="<?php echo wc_get_page_permalink('/my-account/view-order/' . $order->get_id()) ?>" method="get">
-        <button type="submit"><?php echo wc_get_page_permalink('/my-account/view-order/' . $order->get_id()) ?></button>
-      </form>
-      to mark your order as complete
+        If you already picked up your order, click on the link below to complete your order. You may need to log in to do
+        the following action
+        <form action="<?php echo site_url() . '/my-account/view-order/' . $order->get_id() ?>" method="get">
+            <input id="completed" type="hidden" name="completed" value="1">
+            <button type="submit">I already picked up my order</button>
+        </form>
     </p>
 <?php endif; ?>
 


### PR DESCRIPTION
This PR creates a new template for a new email. However, this email does not trigger in the same manner as the previous custom email classes; its purpose is to provide a hook for us to call programmatically rather than trigger on status change.

The reason for creating a new email class and its corresponding templates was due to the inconsistency of WooCommerce email hooks. When calling it within our custom hook, some times the new hook fires and sometimes it does not. Will revisit this area one more time before officially committing to this new change.   

**Requirements:**
- [x] "Ready for Pick Up Reminder" emails should provide a hook for us to call from anywhere in our Copy Center application (theme or plugin).
- [x] This new template should not trigger on any order status change.
- [x] Each new email template should have new content to notify customers that it is this is a **reminder** email for orders that are "Ready for Pick Up".
- [x] There should be a link that allows the user to update their order status to "Complete".

**Additional Requirements:**
- [ ] Update README to outline developer information of the plugin.

**Bugs:**
- [x] Fill email dynamically with user settings. Currently, default email templates such as **Subject** are not replaced by dynamic text.